### PR TITLE
Refactor the crate to be more ergonomic (Breaking changes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,8 @@ exclude = ["target", ".github"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+serde_with = "3.12.0"
+
+[dev-dependencies]
 serde_json = "1.0"
+anyhow = "1.0.98"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,24 @@
 [package]
 name = "vicardi"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 homepage = "https://oss.uzinfocom.uz"
 repository = "https://github.com/uzinfocom-org/vicardi"
 description = "JSON VCardArray Generator that uses Serde"
-authors = ["UwUssimo Robinson <uwussimo@icloud.com> (https://uwussi.moe)"]
+authors = [
+    "UwUssimo Robinson <uwussimo@icloud.com> (https://uwussi.moe)",
+    "Maksym Kuzmin <m.kuzmin.r@gmail.com> (https://github.com/m-kuzmin)",
+]
 keywords = ["jcard", "vcardarray", "serde"]
 readme = "readme.md"
 categories = ["data-structures"]
 license = "GPL-3.0"
-exclude = ["target", ".github"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+exclude = ["target", ".github", "flake.lock", "**/*.nix"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_with = "3.12.0"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="https://raw.githubusercontent.com/uzinfocom-org/website/main/src/images/logo.svg" alt="logo" height="100" align="left">
 <h1 style="display: inline">Vicardi</h1>
 
-Serde serializatsiya va deserializatsiyasi yordamida qilingan VCard JSON generatori
+jCard (vCard in JSON format) serde serialization and deserialization.
 
 [![GitHub top language](https://img.shields.io/github/languages/top/uzinfocom-org/vicardi?style=flat-square&logo=github)](https://github.com/uzinfocom-org/vicardi)
 [![Chat](https://img.shields.io/badge/Chat-grey?style=flat-square&logo=telegram)](https://t.me/xinuxuz)
@@ -10,34 +10,46 @@ Serde serializatsiya va deserializatsiyasi yordamida qilingan VCard JSON generat
 
 </header>
 
-## Haqida
+## About
 
-Bizning CCTLD tomonidan ishlab chiqilgan sistema ICANN servislari bilan muloqot qilish uchun JCard (VCardArray) formatini ishlatadi. Afsuski,
-VCardArray generatsion biron kutubxona mavjud bo'lmaganligi sababli o'zimizning kutubxonamizni ishlab chiqdik va ushbu kutubxonani O'zbekistondagi
-.uz TLD domenlarini ishlashini ham tez, ham nustahkam qilib RDAP tizimini yaratishda ishlatdik.
+Our CCTLD-developed system uses the jCard format to communicate with ICANN services. Unfortunately, since there is no 
+jCard serde crate available, we developed our own library and used this library to create an RDAP system that makes the
+.uz TLD domains in Uzbekistan both fast and robust.
 
-> Ushbu kutubxona RFC7483 standartiga binoan ishlab chiqilgan. Ko'proq ma'lumotlar uchun shu yerga kiring:
-> https://datatracker.ietf.org/doc/html/rfc7483
+> [!NOTE]
+> This library is developed according to the [RFC 7483](https://datatracker.ietf.org/doc/html/rfc7483) standard.
+> 
+> While the crate should be fully RFC compliant, please open an issue if you spot anything wrong.
 
-## Qulayliklar
 
-- Tayyor "binding"lar
-- Serde yordamida serializatsiyadan o'tgan `struct` lar
-- (Yordamchi macroslar va shu kabi qulayliklar keyinchalik qo'shish niyat qilingan)
+## Using Vicardi
 
-> Bu proyekt hozir sinov bosqichidan o'tmoqda. Agarda bironta xatolikka duchor
-> bo'lsangiz, xatolik haqida [e'lon](https://github.com/uzinfocom-org/vicardi/issues/new)
-> qoldirishni unutmang.
+```rust
+use vicardi::*;
+use serde_json::json;
 
-## O'rnatish
+fn main() -> anyhow::Result<()> {
+    let mut vcard = Vcard::default();
+    vcard.push(Property::new_fn("John Doe", None));
 
-Ushbu qatorni Cargo.toml faylingizga joylashtiring:
+    let json = json!([
+        "vcard",
+        [
+            ["version", {}, "text", "4.0"],
+            ["fn", {}, "text", "John Doe"]
+        ]
+    ]);
 
-```toml
-[dependencies]
-vicardi = "0.1.7"
+    let parsed: Vcard = serde_json::from_value(json.clone())?;
+
+    assert_eq!(serde_json::to_value(&vcard)?, json);
+    assert_eq!(parsed, vcard);
+    Ok(())
+}
 ```
 
-## Litsenziya
+See the [documentation](https://docs.rs/vicardi/latest/vicardi/) for more details.
+
+## License
     
-Ushbu kutubxona GPL-3.0 litsenziya ostida distributsiya qilinadi. Ko'proq ma'lumot uchun [LICENSE](./LICENSE) ko'zdan kechiring!
+This library is distributed under the GPL-3.0 license. See the [LICENSE](./LICENSE) for more information!

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1743800763,
+        "narHash": "sha256-YFKV+fxEpMgP5VsUcM6Il28lI0NlpM7+oB1XxbBAYCw=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "ed0232117731a4c19d3ee93aa0c382a8fe754b01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1745377448,
+        "narHash": "sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "507b63021ada5fee621b6ca371c4fca9ca46f52c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1745377448,
+        "narHash": "sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "507b63021ada5fee621b6ca371c4fca9ca46f52c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1680978846,
+        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
+        "owner": "nix-systems",
+        "repo": "x86_64-linux",
+        "rev": "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "x86_64-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "vicardi - Rust jCard parser";
+
+  inputs = {
+    systems.url = "github:nix-systems/x86_64-linux";
+
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+      inputs.systems.follows = "systems";
+    };
+
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+naersk.url="github:nix-community/naersk";
+  };
+
+  outputs = {
+    self,
+    flake-utils,
+    nixpkgs,
+    naersk
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        inherit (nixpkgs) lib;
+	naersk'=naersk.lib.${system};
+      in {
+        formatter = pkgs.alejandra;
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            rustc
+            cargo
+            clippy
+            rustfmt
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,21 +11,21 @@
 
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-naersk.url="github:nix-community/naersk";
+    naersk.url = "github:nix-community/naersk";
   };
 
   outputs = {
     self,
+    systems,
     flake-utils,
     nixpkgs,
-    naersk
-    ...
+    naersk,
   }:
     flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (nixpkgs) lib;
-	naersk'=naersk.lib.${system};
+        naersk' = naersk.lib.${system};
       in {
         formatter = pkgs.alejandra;
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,0 +1,173 @@
+use serde::{
+    de::{Error, Unexpected, Visitor},
+    Deserialize,
+};
+
+use crate::{Property, PropertyValue, Vcard};
+
+impl<'de> Deserialize<'de> for Vcard {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct VcardVisitor;
+        impl<'de> Visitor<'de> for VcardVisitor {
+            type Value = Vcard;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("an RFC 7095 jCard")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let header: Option<String> = seq.next_element()?;
+                match header.as_deref() {
+                    Some("vcard") => {}
+                    Some(other) => {
+                        return Err(A::Error::invalid_value(
+                            Unexpected::Str(other),
+                            &r#"a "vcard" header string"#,
+                        ))
+                    }
+                    None => {
+                        return Err(A::Error::invalid_value(
+                            Unexpected::Seq,
+                            &r#"a non-empty array starting with a "vcard" header"#,
+                        ))
+                    }
+                }
+
+                let mut version = String::default();
+                let Some(mut properties) = seq.next_element::<Vec<Property>>()? else {
+                    return Err(A::Error::invalid_value(
+                        Unexpected::Seq,
+                        &r#"an array of jCard properties as the second element"#,
+                    ));
+                };
+
+                let mut version_index = None;
+
+                for (i, property) in properties.iter_mut().enumerate() {
+                    if property.name.to_lowercase().as_str() != "version" {
+                        continue;
+                    }
+
+                    version_index = Some(i);
+
+                    version = match property.values.as_slice() {
+                        [PropertyValue::String(_)] => {
+                            let PropertyValue::String(moved_string) = property.values.remove(0)
+                            else {
+                                unreachable!()
+                            };
+                            moved_string
+                        }
+                        [PropertyValue::Structured(structured)] => match structured.as_slice() {
+                            [_] => {
+                                let PropertyValue::String(moved_string) = property.values.remove(0)
+                                else {
+                                    unreachable!()
+                                };
+                                moved_string
+                            }
+
+                            [] | [_, _, ..] => {
+                                return Err(A::Error::invalid_length(
+                                    property.values.len(),
+                                    &"a non-structured version property",
+                                ))
+                            }
+                        },
+                        [] | [_, _, ..] => {
+                            return Err(A::Error::invalid_length(
+                                property.values.len(),
+                                &"exactly one value in the jCard version property",
+                            ))
+                        }
+                    };
+
+                    break;
+                }
+
+                version_index.map(|i| properties.remove(i));
+
+                Ok(Vcard {
+                    version,
+                    properties,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(VcardVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for Property {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct PropertyVisitor;
+
+        impl<'de> Visitor<'de> for PropertyVisitor {
+            type Value = Property;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("an RFC 7095 jCard property")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                /// The number of elements before the `values` array starts at this level in the property
+                const FIXED_ELEMENTS: usize = 3;
+
+                let mut counter = (0..).into_iter();
+                let mut len_err = || {
+                    Err(A::Error::invalid_length(
+                        counter.next().unwrap(),
+                        &"an array of at least 4 elements",
+                    ))
+                };
+
+                let Some(name) = seq.next_element()? else {
+                    return len_err();
+                };
+                let Some(parameters) = seq.next_element()? else {
+                    return len_err();
+                };
+                let Some(value_type) = seq.next_element()? else {
+                    return len_err();
+                };
+
+                let mut values = seq
+                    .size_hint()
+                    .map(|len| Vec::with_capacity(len.saturating_sub(FIXED_ELEMENTS)))
+                    .unwrap_or_default();
+
+                while let Some(value) = seq.next_element()? {
+                    values.push(value);
+                }
+
+                if values.is_empty() {
+                    return Err(A::Error::invalid_length(
+                        3,
+                        &"at least one value of the jCard property",
+                    ));
+                }
+
+                Ok(Property {
+                    name,
+                    parameters,
+                    value_type,
+                    values,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(PropertyVisitor)
+    }
+}

--- a/src/de.rs
+++ b/src/de.rs
@@ -125,7 +125,7 @@ impl<'de> Deserialize<'de> for Property {
                 /// The number of elements before the `values` array starts at this level in the property
                 const FIXED_ELEMENTS: usize = 3;
 
-                let mut counter = (0..).into_iter();
+                let mut counter = 0..;
                 let mut len_err = || {
                     Err(A::Error::invalid_length(
                         counter.next().unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,58 @@
-use crate::models::{Address, Telephone};
+//!<header>
+//!<img src="https://raw.githubusercontent.com/uzinfocom-org/website/main/src/images/logo.svg" alt="logo" height="100" align="left" style="padding-right: 1em;">
+//!<h1 style="display: inline">Vicardi</h1>
+//!
+//!jCard (vCard in JSON format) serde serialization and deserialization.
+//!
+//![![GitHub top language](https://img.shields.io/github/languages/top/uzinfocom-org/vicardi?style=flat-square&logo=github)](https://github.com/uzinfocom-org/vicardi)
+//![![Chat](https://img.shields.io/badge/Chat-grey?style=flat-square&logo=telegram)](https://t.me/xinuxuz)
+//![![Test CI](https://github.com/uzinfocom-org/vicardi/actions/workflows/test.yml/badge.svg)](https://github.com/uzinfocom-org/vicardi/actions/workflows/test.yml)
+//!
+//!</header>
+//!
+//! # The jCard format
+//!
+//! The jCard format is quite simple. A jCard is an arrary with 2 elements:
+//!
+//! - The string "vcard"
+//! - A nested array with the vCard properties
+//!   - Each element in the array is another array with at least 4 elements:
+//!     - Name (e.g. "fn")
+//!     - Properties (a string to string map)
+//!     - Value type (e.g. "text")
+//!     - 1+ values of that property
+//!
+//! ```json
+//! [
+//!   "vcard",
+//!   [
+//!     ["version", {}, "text", "4.0"],
+//!     ["fn", {}, "text", "Vicardi"],
+//!     ["categories", {}, "text", "rust", "serde"],
+//!     ...
+//!   ]
+//! ]
+//! ```
+//!
+//! The entire array is represented by the [`Vcard`] type. Each property is a [`Property`] and it can have 1 or more
+//! [`PropertyValue`]s.
+//!
+//! **A note on the version property:**
+//!
+//! The RFC requires that the first element in the array is a version property. At the moment, this crate does not
+//! enforce any rules regarding the position or number of version properties. However, the first occurance of the
+//! version property is removed from the array during deserialization. The value of the version is stored in the
+//! [`Vcard::version`] field.
+//!
+//! During serialization, the value of [`Vcard::version`] is placed at index 0 in the properties array.
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 mod de;
-pub mod models;
 mod ser;
+
+pub use structured::*;
+pub mod structured;
 
 /// A jCard serde type
 #[derive(Debug, Clone, PartialEq)]
@@ -56,6 +104,15 @@ pub struct Property {
     pub values: Vec<PropertyValue>,
 }
 
+/// A [`Property::values`] can either be a simple string or an array of strings.
+///
+/// ```json
+/// ["fn", {}, "text", "Vicardi"]
+///
+/// ["org", {}, "text",
+///     ["Organization", "Department", "etc"]
+/// ]
+/// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PropertyValue {
@@ -132,7 +189,6 @@ impl Property {
 
     /// # Example
     /// ```rust
-    /// # use vicardi::models::*;
     /// # use vicardi::*;
     /// # use serde_json::json;
     /// # fn main() -> anyhow::Result<()> {
@@ -193,11 +249,9 @@ impl Property {
         Self::new("adr", parameters, "text", address)
     }
 
-    ///
-    /// /// # Example
+    /// # Example
     /// /**
     /// ```rust
-    /// # use vicardi::models::*;
     /// # use vicardi::*;
     /// # use serde_json::json;
     /// # fn main() -> anyhow::Result<()> {
@@ -230,7 +284,6 @@ impl Property {
 
     /// # Example
     /// ```rust
-    /// # use vicardi::models::*;
     /// # use vicardi::*;
     /// # use serde_json::json;
     /// # fn main() -> anyhow::Result<()> {
@@ -265,7 +318,6 @@ impl Property {
 
     /// # Example
     /// ```rust
-    /// # use vicardi::models::*;
     /// # use vicardi::*;
     /// # use serde_json::json;
     /// # fn main() -> anyhow::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,6 @@ impl Property {
     /// # Example
     ///
     /// ```rust
-    /// # use vicardi::models::*;
     /// # use vicardi::*;
     /// # use serde_json::json;
     /// # fn main() -> anyhow::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use crate::models::{Address, Telephone};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+mod de;
 pub mod models;
 mod ser;
 
@@ -115,7 +116,10 @@ impl Property {
     ///     ]
     /// ]);
     ///
-    /// assert_eq!(serde_json::to_value(vcard)?, json);
+    /// let parsed: Vcard = serde_json::from_value(json.clone())?;
+    ///
+    /// assert_eq!(serde_json::to_value(&vcard)?, json);
+    /// assert_eq!(parsed, vcard);
     /// # Ok(())
     /// # }
     /// ```
@@ -175,7 +179,10 @@ impl Property {
     ///     ]
     /// ]);
     ///
-    /// assert_eq!(serde_json::to_value(vcard)?, json);
+    /// let parsed: Vcard = serde_json::from_value(json.clone())?;
+    ///
+    /// assert_eq!(serde_json::to_value(&vcard)?, json);
+    /// assert_eq!(parsed, vcard);
     /// # Ok(())
     /// # }
     /// ```
@@ -207,7 +214,10 @@ impl Property {
     ///     ]
     /// ]);
     ///
-    /// assert_eq!(serde_json::to_value(vcard)?, json);
+    /// let parsed: Vcard = serde_json::from_value(json.clone())?;
+    ///
+    /// assert_eq!(serde_json::to_value(&vcard)?, json);
+    /// assert_eq!(parsed, vcard);
     /// # Ok(())
     /// # }
     /// ```
@@ -235,7 +245,10 @@ impl Property {
     ///     ]
     /// ]);
     ///
-    /// assert_eq!(serde_json::to_value(vcard)?, json);
+    /// let parsed: Vcard = serde_json::from_value(json.clone())?;
+    ///
+    /// assert_eq!(serde_json::to_value(&vcard)?, json);
+    /// assert_eq!(parsed, vcard);
     /// # Ok(())
     /// # }
     /// ```
@@ -267,7 +280,10 @@ impl Property {
     ///     ]
     /// ]);
     ///
-    /// assert_eq!(serde_json::to_value(vcard)?, json);
+    /// let parsed: Vcard = serde_json::from_value(json.clone())?;
+    ///
+    /// assert_eq!(serde_json::to_value(&vcard)?, json);
+    /// assert_eq!(parsed, vcard);
     /// # Ok(())
     /// # }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,179 +1,289 @@
-use crate::models::{Location, Telephone, VCard, VElement};
+use crate::models::{Address, Telephone};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub mod models;
+mod ser;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct VCardArray {
-    elements: Vec<Vec<VElement>>,
+/// A jCard serde type
+#[derive(Debug, Clone, PartialEq)]
+pub struct Vcard {
+    /// A parsed out jCard version property.
+    pub version: String,
+    /// jCard properties
+    ///
+    /// # Notes
+    ///
+    /// - Do not include the `version` type property in this array. Instead, set the [`Vcard::version`] property.
+    ///   `["version,{},"text",version]` will be inserted by the [`Serialize`] implementation.
+    pub properties: Vec<Property>,
 }
 
-impl VCardArray {
-    pub fn new() -> Self {
-        VCardArray {
-            elements: vec![vec![
-                VElement::Element("version".to_string()),
-                VElement::Dictionary(HashMap::new()),
-                VElement::Element("text".to_string()),
-                VElement::Element("4.0".to_string()),
-            ]],
-        }
-    }
-
-    fn add_vcard(
-        &mut self,
-        category: String,
-        properties: HashMap<String, String>,
-        types: String,
-        value: VElement,
-    ) {
-        self.elements.push(vec![
-            VElement::Element(category),
-            VElement::Dictionary(properties),
-            VElement::Element(types),
-            value,
-        ]);
-    }
-
-    pub fn add_fn(&mut self, name: String, surname: String) {
-        self.add_vcard(
-            "fn".to_string(),
-            HashMap::new(),
-            "text".to_string(),
-            VElement::Element(format!("{} {}", name, surname)),
-        )
-    }
-
-    pub fn add_org(&mut self, name: Option<String>, unit: Option<String>) {
-        self.add_vcard(
-            "org".to_string(),
-            HashMap::new(),
-            "text".to_string(),
-            VElement::Element(format!(
-                "{} {}",
-                name.unwrap_or_else(|| "".to_string()),
-                unit.unwrap_or_else(|| "".to_string())
-            )),
-        )
-    }
-
-    pub fn add_address(&mut self, location: Location) {
-        let mut properties: HashMap<String, String> = HashMap::new();
-
-        properties.insert("cc".to_string(), "AT".to_string());
-
-        // Array pn given order
-        // the post office box;
-        // the extended address (e.g., apartment or suite number);
-        // the street address;
-        // the locality (e.g., city);
-        // the region (e.g., state or province);
-        // the postal code;
-        // the country name (full name);
-        self.add_vcard(
-            "adr".to_string(),
-            properties,
-            "text".to_string(),
-            VElement::Array(vec![
-                location.post_office_box.unwrap_or_else(|| "".to_string()),
-                location.extended_address.unwrap_or_else(|| "".to_string()),
-                location.street_address.unwrap_or_else(|| "".to_string()),
-                location.locality.unwrap_or_else(|| "".to_string()),
-                location.region.unwrap_or_else(|| "".to_string()),
-                location.postal_code.unwrap_or_else(|| "".to_string()),
-                location.country.unwrap_or_else(|| "".to_string()),
-            ]),
-        )
-    }
-
-    pub fn add_tel(&mut self, types: Telephone, number: String) {
-        let mut properties: HashMap<String, String> = HashMap::new();
-
-        match types {
-            Telephone::Voice => {
-                properties.insert("type".to_string(), "voice".to_string());
-            }
-            Telephone::Fax => {
-                properties.insert("type".to_string(), "fax".to_string());
-            }
-        }
-
-        self.add_vcard(
-            "tel".to_string(),
-            properties,
-            "uri".to_string(),
-            VElement::Element(format!("tel:{}", number)),
-        )
-    }
-
-    pub fn add_email(&mut self, email: String) {
-        self.add_vcard(
-            "email".to_string(),
-            HashMap::new(),
-            "text".to_string(),
-            VElement::Element(email),
-        );
-    }
-
-    pub fn to_json(&self, pretty: bool) -> String {
-        let array: Vec<VCard> = vec![
-            VCard::Element("vcard".to_string()),
-            VCard::ElementArray(self.elements.clone()),
-        ];
-
-        match pretty {
-            true => serde_json::to_string_pretty(&array).unwrap(),
-            false => serde_json::to_string(&array).unwrap(),
+impl Default for Vcard {
+    fn default() -> Self {
+        Self {
+            version: "4.0".into(),
+            properties: Vec::default(),
         }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::{Location, VCardArray};
+/// An entry in the jCard.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Property {
+    /// Aka the type. E.g. `"fn"`.
+    pub name: String,
 
-    #[test]
-    fn test_fn() {
-        let mut vcard = VCardArray::new();
+    /// The list of parameters such as the laguage or the preference value.
+    pub parameters: HashMap<String, String>,
 
-        vcard.add_fn("John".to_string(), "Doe".to_string());
+    /// The value type. E.g. `"text"`
+    pub value_type: String,
 
-        let result =
-            "[\"vcard\",[[\"version\",{},\"text\",\"4.0\"],[\"fn\",{},\"text\",\"John Doe\"]]]"
-                .to_string();
-        assert_eq!(vcard.to_json(false), result);
+    /// Either a single or multiple values of the jCard property.
+    ///
+    /// When the array has multiple elements, they are appended at the level of the property array in jCard format:
+    ///
+    /// ```json
+    /// ["categories", {}, "text", "rust", "serde"]
+    /// ```
+    ///
+    /// Where rust and serde are [`PropertyValue::String`]
+    ///
+    /// For a structured property, use [`PropertyValue::Structured`]. See [`Property::new_adr`] for an example of a
+    /// structured property.
+    pub values: Vec<PropertyValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PropertyValue {
+    String(String),
+    Structured(Vec<String>),
+}
+
+impl Vcard {
+    /// Appends a property to the vCard.
+    ///
+    /// Check the examples for [`Property`]'s constructors for examples of how to easily append different vCard
+    /// properties.
+    pub fn push(&mut self, property: impl Into<Property>) {
+        self.properties.push(property.into());
+    }
+}
+
+impl Property {
+    /// Creates a new property, where [`Property::values`] is a `vec![value]`.
+    pub fn new(
+        name: impl ToString,
+        parameters: impl Into<Option<HashMap<String, String>>>,
+        value_type: impl ToString,
+        value: impl Into<PropertyValue>,
+    ) -> Self {
+        Self::new_multivalued(name, parameters, value_type, vec![value.into()])
     }
 
-    #[test]
-    fn test_adr() {
-        let mut vcard = VCardArray::new();
-
-        vcard.add_address(Location {
-            post_office_box: None,
-            extended_address: None,
-            street_address: Some("Jakob-Haringer-Strasse 8/V".to_string()),
-            locality: Some("Salzburg".to_string()),
-            region: Some("Salzburg".to_string()),
-            postal_code: Some(5020.to_string()),
-            country: None,
-        });
-
-        let result =
-            "[\"vcard\",[[\"version\",{},\"text\",\"4.0\"],[\"adr\",{\"cc\":\"AT\"},\"text\",[\"\",\"\",\"Jakob-Haringer-Strasse 8/V\",\"Salzburg\",\"Salzburg\",\"5020\",\"\"]]]]"
-                .to_string();
-        assert_eq!(vcard.to_json(false), result);
+    pub fn new_multivalued(
+        name: impl ToString,
+        parameters: impl Into<Option<HashMap<String, String>>>,
+        value_type: impl ToString,
+        values: Vec<PropertyValue>,
+    ) -> Self {
+        Self {
+            name: name.to_string(),
+            parameters: parameters.into().unwrap_or_default(),
+            value_type: value_type.to_string(),
+            values,
+        }
     }
 
-    #[test]
-    fn test_email() {
-        let mut vcard = VCardArray::new();
+    /// # Example
+    ///
+    /// ```rust
+    /// # use vicardi::models::*;
+    /// # use vicardi::*;
+    /// # use serde_json::json;
+    /// # fn main() -> anyhow::Result<()> {
+    /// let mut vcard = Vcard::default();
+    /// vcard.push(Property::new_fn("John Doe", None));
+    ///
+    /// let json = json!([
+    ///     "vcard",
+    ///     [
+    ///         ["version", {}, "text", "4.0"],
+    ///         ["fn", {}, "text", "John Doe"]
+    ///     ]
+    /// ]);
+    ///
+    /// assert_eq!(serde_json::to_value(vcard)?, json);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_fn(
+        formatted: impl ToString,
+        parameters: impl Into<Option<HashMap<String, String>>>,
+    ) -> Self {
+        Self::new("fn", parameters, "text", formatted)
+    }
 
-        vcard.add_email("sample@mail.com".to_string());
+    /// # Example
+    /// ```rust
+    /// # use vicardi::models::*;
+    /// # use vicardi::*;
+    /// # use serde_json::json;
+    /// # fn main() -> anyhow::Result<()> {
+    /// let mut vcard = Vcard::default();
+    ///
+    /// let address = Address {
+    ///     street_address: "Jakob-Haringer-Strasse 8/V".to_string(),
+    ///     locality: "Salzburg".to_string(),
+    ///     region: "Salzburg".to_string(),
+    ///     postal_code: 5020.to_string(),
+    ///
+    ///     ..Default::default()
+    /// };
+    ///
+    /// vcard.push(Property::new_adr(
+    ///     address.clone(),
+    ///     Some([("pref".to_string(), "1".to_string())].into_iter().collect())
+    /// ));
+    /// vcard.push(address);
+    ///
+    /// let json = json!([
+    ///     "vcard",
+    ///     [
+    ///         ["version", {}, "text", "4.0"],
+    ///
+    ///         ["adr", {"pref": "1"}, "text", [
+    ///             "",
+    ///             "",
+    ///             "Jakob-Haringer-Strasse 8/V",
+    ///             "Salzburg",
+    ///             "Salzburg",
+    ///             "5020",
+    ///             ""
+    ///         ]],
+    ///         ["adr", {}, "text", [
+    ///             "",
+    ///             "",
+    ///             "Jakob-Haringer-Strasse 8/V",
+    ///             "Salzburg",
+    ///             "Salzburg",
+    ///             "5020",
+    ///             ""
+    ///         ]]
+    ///     ]
+    /// ]);
+    ///
+    /// assert_eq!(serde_json::to_value(vcard)?, json);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_adr(
+        address: Address,
+        parameters: impl Into<Option<HashMap<String, String>>>,
+    ) -> Self {
+        Self::new("adr", parameters, "text", address)
+    }
 
-        let result =
-            "[\"vcard\",[[\"version\",{},\"text\",\"4.0\"],[\"email\",{},\"text\",\"sample@mail.com\"]]]"
-                .to_string();
-        assert_eq!(vcard.to_json(false), result);
+    ///
+    /// /// # Example
+    /// /**
+    /// ```rust
+    /// # use vicardi::models::*;
+    /// # use vicardi::*;
+    /// # use serde_json::json;
+    /// # fn main() -> anyhow::Result<()> {
+    /// let mut vcard = Vcard::default();
+    /// vcard.push(Property::new_org("Vicardi", None));
+    /// vcard.push(Property::new_org(PropertyValue::Structured(vec!["Vicardi".into(), "Rust development".into()]), None));
+    ///
+    /// let json = json!([
+    ///     "vcard",
+    ///     [
+    ///         ["version", {}, "text", "4.0"],
+    ///         ["org", {}, "text", "Vicardi"],
+    ///         ["org", {}, "text", ["Vicardi", "Rust development"]]
+    ///     ]
+    /// ]);
+    ///
+    /// assert_eq!(serde_json::to_value(vcard)?, json);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_org(
+        org: impl Into<PropertyValue>,
+        parameters: impl Into<Option<HashMap<String, String>>>,
+    ) -> Self {
+        Self::new("org", parameters, "text", org)
+    }
+
+    /// # Example
+    /// ```rust
+    /// # use vicardi::models::*;
+    /// # use vicardi::*;
+    /// # use serde_json::json;
+    /// # fn main() -> anyhow::Result<()> {
+    /// let mut vcard = Vcard::default();
+    /// vcard.push(Property::new_tel(Telephone::Voice, "+1-555-555-5555", None));
+    ///
+    /// let json = json!([
+    ///     "vcard",
+    ///     [
+    ///         ["version", {}, "text", "4.0"],
+    ///         ["tel", {"type": "voice"}, "uri", "tel:+1-555-555-5555"]
+    ///     ]
+    /// ]);
+    ///
+    /// assert_eq!(serde_json::to_value(vcard)?, json);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_tel(
+        phone_type: impl Into<Telephone>,
+        number: impl AsRef<str>,
+        parameters: impl Into<Option<HashMap<String, String>>>,
+    ) -> Self {
+        let mut parameters = parameters.into().unwrap_or_default();
+        parameters.insert("type".into(), phone_type.into().to_string());
+
+        Self::new("tel", parameters, "uri", format!("tel:{}", number.as_ref()))
+    }
+
+    /// # Example
+    /// ```rust
+    /// # use vicardi::models::*;
+    /// # use vicardi::*;
+    /// # use serde_json::json;
+    /// # fn main() -> anyhow::Result<()> {
+    /// let mut vcard = Vcard::default();
+    /// vcard.push(Property::new_email("vicardi@example.com", None));
+    ///
+    /// let json = json!([
+    ///     "vcard",
+    ///     [
+    ///         ["version", {}, "text", "4.0"],
+    ///         ["email", {}, "text", "vicardi@example.com"]
+    ///     ]
+    /// ]);
+    ///
+    /// assert_eq!(serde_json::to_value(vcard)?, json);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_email(
+        email: impl ToString,
+        parameters: impl Into<Option<HashMap<String, String>>>,
+    ) -> Self {
+        Self::new("email", parameters, "text", email.to_string())
+    }
+}
+
+impl<T> From<T> for PropertyValue
+where
+    T: ToString,
+{
+    fn from(value: T) -> Self {
+        PropertyValue::String(value.to_string())
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,39 +1,75 @@
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{convert::Infallible, fmt::Display, str::FromStr};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", untagged)]
-pub enum VElement {
-    Element(String),
-    Dictionary(HashMap<String, String>),
-    Array(Vec<String>),
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+use crate::{Property, PropertyValue};
+
+#[derive(Debug, Clone, Default)]
+pub struct Address {
+    pub post_office_box: String,
+    pub extended_address: String,
+    pub street_address: String,
+    pub locality: String,
+    pub region: String,
+    pub postal_code: String,
+    pub country: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", untagged)]
-pub enum VCard {
-    Element(String),
-    ElementArray(Vec<Vec<VElement>>),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum VCardField {
-    Version,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Location {
-    pub post_office_box: Option<String>,
-    pub extended_address: Option<String>,
-    pub street_address: Option<String>,
-    pub locality: Option<String>,
-    pub region: Option<String>,
-    pub postal_code: Option<String>,
-    pub country: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, SerializeDisplay, DeserializeFromStr)]
 pub enum Telephone {
     Fax,
     Voice,
+    Other(String),
+}
+
+impl From<Address> for PropertyValue {
+    fn from(address: Address) -> Self {
+        PropertyValue::Structured(
+            [
+                address.post_office_box,
+                address.extended_address,
+                address.street_address,
+                address.locality,
+                address.region,
+                address.postal_code,
+                address.country,
+            ]
+            .into_iter()
+            .collect(),
+        )
+    }
+}
+
+impl From<Address> for Property {
+    fn from(address: Address) -> Self {
+        Self::new("adr", None, "text", address)
+    }
+}
+
+impl Display for Telephone {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
+impl AsRef<str> for Telephone {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Fax => "fax",
+            Self::Voice => "voice",
+            Self::Other(other) => other.as_ref(),
+        }
+    }
+}
+
+impl FromStr for Telephone {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "fax" => Self::Fax,
+            "voice" => Self::Voice,
+            other => Self::Other(other.to_string()),
+        })
+    }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -14,7 +14,7 @@ impl Serialize for Vcard {
         vcard.serialize_element("vcard")?;
 
         struct VersionPrefix<'a, T>(&'a str, &'a [T]);
-        impl<'a, T> Serialize for VersionPrefix<'a, T>
+        impl<T> Serialize for VersionPrefix<'_, T>
         where
             T: Serialize,
         {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,4 +1,7 @@
-use serde::{ser::SerializeSeq as _, Serialize};
+use serde::{
+    ser::{Error, SerializeSeq as _},
+    Serialize,
+};
 
 use crate::{Property, Vcard};
 
@@ -41,6 +44,12 @@ impl Serialize for Property {
     where
         S: serde::Serializer,
     {
+        if self.values.is_empty() {
+            return Err(S::Error::custom(
+                "at least one value must be present in a property",
+            ));
+        }
+
         let mut seq = serializer.serialize_seq(Some(3 + self.values.len()))?;
 
         seq.serialize_element(&self.name)?;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,0 +1,55 @@
+use serde::{ser::SerializeSeq as _, Serialize};
+
+use crate::{Property, Vcard};
+
+impl Serialize for Vcard {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut vcard = serializer.serialize_seq(Some(2))?;
+        vcard.serialize_element("vcard")?;
+
+        struct VersionPrefix<'a, T>(&'a str, &'a [T]);
+        impl<'a, T> Serialize for VersionPrefix<'a, T>
+        where
+            T: Serialize,
+        {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                let mut seq = serializer.serialize_seq(Some(self.1.len() + 1))?;
+
+                seq.serialize_element(&Property::new("version", None, "text", self.0))?;
+
+                self.1
+                    .iter()
+                    .try_for_each(|prop| seq.serialize_element(prop))?;
+
+                seq.end()
+            }
+        }
+
+        vcard.serialize_element(&VersionPrefix(&self.version, &self.properties))?;
+        vcard.end()
+    }
+}
+
+impl Serialize for Property {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(3 + self.values.len()))?;
+
+        seq.serialize_element(&self.name)?;
+        seq.serialize_element(&self.parameters)?;
+        seq.serialize_element(&self.value_type)?;
+        self.values
+            .iter()
+            .try_for_each(|v| seq.serialize_element(v))?;
+
+        seq.end()
+    }
+}

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -1,6 +1,8 @@
+/// Helper types to construct structured properties
 use std::{convert::Infallible, fmt::Display, str::FromStr};
 
 use serde_with::{DeserializeFromStr, SerializeDisplay};
+use thiserror::Error;
 
 use crate::{Property, PropertyValue};
 
@@ -39,6 +41,50 @@ impl From<Address> for PropertyValue {
         )
     }
 }
+
+impl From<[String; 7]> for Address {
+    fn from(value: [String; 7]) -> Self {
+        let [post_office_box, extended_address, street_address, locality, region, postal_code, country] =
+            value;
+
+        Self {
+            post_office_box,
+            extended_address,
+            street_address,
+            locality,
+            region,
+            postal_code,
+            country,
+        }
+    }
+}
+
+impl TryFrom<Vec<String>> for Address {
+    type Error = InvalidStructuredAddress;
+
+    fn try_from(value: Vec<String>) -> Result<Self, Self::Error> {
+        let Ok(
+            [post_office_box, extended_address, street_address, locality, region, postal_code, country],
+        ) = TryInto::<[String; 7]>::try_into(value)
+        else {
+            return Err(InvalidStructuredAddress);
+        };
+
+        Ok(Self {
+            post_office_box,
+            extended_address,
+            street_address,
+            locality,
+            region,
+            postal_code,
+            country,
+        })
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("Invalid strucutured address")]
+pub struct InvalidStructuredAddress;
 
 impl From<Address> for Property {
     fn from(address: Address) -> Self {


### PR DESCRIPTION
## Changelog

- Replace awkward `Vcard {elelements: [[VElement]]}` with a more type safe `VCard { properties, ... }` and implement  `Serialize` & `Deserialize` for it.
- Convert unit tests into doctests to make that code more useful.
- Add docs.
- Replace `Vcard::add_*` with `Property::new_*` constructors. `Vcard` only has a `push` method now.
- Use more `impl Into<T>` as parameters to constructors to allow the user to suppy different types,
  which are efficiently converted into the appropriate types. For example:
```rust
Property::new("fn", ..);
Property::new(String::from("fn"), ..);
```
- Remove the `{cc: AT}` parameter from the address property. This parameter is not required by
  RFC 6350 (vCard) nor RFC 7095 (jCard), so it was removed. If you rely on this parameter, please add it at
  the call site.

------------------

- Add @m-kuzmin to the crate authors in Cargo.toml